### PR TITLE
remove intro bits in results-book

### DIFF
--- a/docs/ampseeker-results/_toc.yml
+++ b/docs/ampseeker-results/_toc.yml
@@ -4,10 +4,6 @@
 format: jb-book
 root: intro
 parts:
-- caption: Introduction
-  chapters:
-  - file: notebooks/workflow_setup
-  - file: notebooks/running_the_workflow
 - caption: Results
   chapters:
   - file: notebooks/IGV-explore

--- a/docs/ampseeker-results/intro.md
+++ b/docs/ampseeker-results/intro.md
@@ -1,8 +1,8 @@
 # AmpSeeker
 
-Welcome to [AmpSeeker](https://github.com/sanjaynagi/AmpSeeker/), an Amplicon Sequencing data analysis pipeline written in Snakemake.
+Welcome to the [AmpSeeker](https://github.com/sanjaynagi/AmpSeeker/) results web-book, built using papermill and Jupyter-book.
 
-AmpSeeker is a compuational pipeline designed to analyse high-throughput Illumina MiSeq whole-genome sequencing data of custom amplicon panels. These panels target multiple loci of interest in a single assay. AmpSeeker is capable of analysing amplicon sequence data for potentially any organism, provided an appropriate reference sequence, SNP targets, and target genomic regions. Currently, the workflow allows users to perform genome alignment, sequence coverage calculation, and variant calling. In addition, the workflow produces an interactive IGV-Notebook, which facilitates read alignment investigation, and an HTML report that includes a diagrammatic job execution graph along with computation times of all software tools. Workflow tools are defined in Conda, ensuring reproducible computation that is platform-agnostic.
+### User guide 
 
 
 ```{tableofcontents}


### PR DESCRIPTION
The results Jupyter book had sections on how to set up the workflow, but these instead need to go in the AmpSeeker docs.