### PR TITLE
robust renaming using bcl convert file mapping

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -36,4 +36,4 @@ analysis:
   allele-frequencies: True
 
 # Specify whether to build jupyter results book
-build-jupyter-book: True
+build-jupyter-book: False

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -8,6 +8,9 @@ dataset = config['dataset']
 metadata = pd.read_csv(config['metadata'], sep="\t")
 samples = metadata['sampleID']
 
+import os
+wkdir = os.getcwd()
+
 include: "rules/common.smk"	
 include: "rules/utilities.smk"
 include: "rules/qc.smk"

--- a/workflow/rules/bcl-convert.smk
+++ b/workflow/rules/bcl-convert.smk
@@ -3,15 +3,21 @@ rule bcl_convert:
         sample_csv = config["illumina-dir"] + "SampleSheet.csv",
         illumina_in_dir = config["illumina-dir"]
     output: 
-        temp(directory("resources/reads/"))
+        reads_dir = temp(directory("resources/reads")),
+        fastq_list = "resources/reads/Reports/fastq_list.csv"
     log:
         "logs/bcl_convert.log"
     shell:
-        "bcl-convert --bcl-input-directory {input.illumina_in_dir} --force --output-directory {output} --sample-sheet {input.sample_csv} 2> {log}"
+        "bcl-convert --bcl-input-directory {input.illumina_in_dir} --force --output-directory {output.reads_dir} --sample-sheet {input.sample_csv} 2> {log}"
+
 
 rule rename_fastq:
+    """
+    If users demultiplex from BCL
+    """
     input:
-        reads = "resources/reads/"
+        reads = "resources/reads/",
+        fastq_list = "resources/reads/Reports/fastq_list.csv"
     output:
         output_reads = expand("results/reads/{sample}_{n}.fastq.gz", n=[1,2], sample=samples)
     log:
@@ -20,7 +26,26 @@ rule rename_fastq:
         "../envs/AmpSeeker-cli.yaml"
     shell:
         """
-        rename s/S[[:digit:]]\+_L001_R// {input.reads}/*.gz 
-        rename s/_001// {input.reads}/*.gz 
-        cp -r resources/reads/* results/reads/ 
+        while IFS="," read -r _ sample_id _ _ read1 read2; do
+            echo renaming $read1 and $read2 to ${{sample_id}}_1.fastq.gz and ${{sample_id}}_2.fastq.gz 2>> {log}
+            mv $read1 results/reads/${{sample_id}}_1.fastq.gz &&
+            mv $read2 results/reads/${{sample_id}}_2.fastq.gz
+        done < {input.fastq_list}
+        """
+
+rule symlink_fastq:
+    """
+    If reads are provided by user and bcl-convert not used
+    """
+    input:
+        input_reads = "resources/reads/{sample}_{n}.fastq.gz"
+    output:
+        output_reads = "results/reads/{sample}_{n}.fastq.gz"
+    log:
+        "logs/symlink_fastq/{sample}_{n}.log"
+    conda:
+        "../envs/AmpSeeker-cli.yaml"
+    shell:
+        """
+        ln -sf {input.input_reads} {output.output_reads}
         """

--- a/workflow/rules/bcl-convert.smk
+++ b/workflow/rules/bcl-convert.smk
@@ -3,7 +3,7 @@ rule bcl_convert:
         sample_csv = config["illumina-dir"] + "SampleSheet.csv",
         illumina_in_dir = config["illumina-dir"]
     output: 
-        reads_dir = temp(directory("resources/reads")),
+        reads_dir = directory("resources/reads"),
         fastq_list = "resources/reads/Reports/fastq_list.csv"
     log:
         "logs/bcl_convert.log"
@@ -30,7 +30,7 @@ rule rename_fastq:
             echo renaming $read1 and $read2 to ${{sample_id}}_1.fastq.gz and ${{sample_id}}_2.fastq.gz 2>> {log}
             mv $read1 results/reads/${{sample_id}}_1.fastq.gz &&
             mv $read2 results/reads/${{sample_id}}_2.fastq.gz
-        done < {input.fastq_list}
+        done < {input.fastq_list} 2> {log}
         """
 
 rule symlink_fastq:
@@ -45,7 +45,10 @@ rule symlink_fastq:
         "logs/symlink_fastq/{sample}_{n}.log"
     conda:
         "../envs/AmpSeeker-cli.yaml"
+    params:
+        wd = wkdir
     shell:
         """
-        ln -sf {input.input_reads} {output.output_reads}
+        echo {params.wd}/{output.output_reads} 2>> {log}
+        ln -sf {params.wd}/{input.input_reads} {params.wd}/{output.output_reads} 2>> {log}
         """


### PR DESCRIPTION
Will close #46 

This PR revamps the file renaming following BCL conversion. It now makes use of `fastq_list.csv` which maps sampleIDs to actual read files outputted by BCL convert. 

I've also now added a symlink for user-provided fastqs from resources/reads to results/reads. 