### PR TITLE
Fix for childioexception error

### DIFF
--- a/workflow/rules/bcl-convert.smk
+++ b/workflow/rules/bcl-convert.smk
@@ -3,8 +3,8 @@ rule bcl_convert:
         sample_csv = config["illumina-dir"] + "SampleSheet.csv",
         illumina_in_dir = config["illumina-dir"]
     output: 
-        reads_dir = directory("resources/reads"),
-        fastq_list = "resources/reads/Reports/fastq_list.csv"
+        reads_dir = directory("resources/bcl_output"),
+        fastq_list = "resources/bcl_output/Reports/fastq_list.csv"
     singularity:
         "docker://nfcore/bclconvert"
     log:
@@ -18,9 +18,9 @@ rule rename_fastq:
     If users demultiplex from BCL than rename, otherwise symlink to results
     """
     input:
-        reads = "resources/reads/",
+        reads = "resources/bcl_output/",
         read_dir = rules.bcl_convert.output,
-        fastq_list = "resources/reads/Reports/fastq_list.csv",
+        fastq_list = "resources/bcl_output/Reports/fastq_list.csv",
     output:
         output_reads = expand("resources/reads/{sample}_{n}.fastq.gz", n=[1,2], sample=samples)
     log:


### PR DESCRIPTION
Addresses #69 
Use a holding directory in `resources` for reads generated from bcl_convert. Reads are subsequently renamed and moved to `reads` dir for usual workflow execution.