### PR TITLE
option to call whole amplicons and move qc analyses to results/qc

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -37,5 +37,6 @@ analysis:
     activate: True
     cohort-column: location 
 
+whole_amplicon_calling: True
 # Specify whether to build jupyter results book
 build-jupyter-book: False

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,7 +17,7 @@ reference-gff3: resources/reference/Anopheles-gambiae-PEST_BASEFEATURES_AgamP4.1
 targets: config/AgamDao.bed
 
 # Specify whether to convert bcl files to fastq
-bcl-convert: True
+bcl-convert: False
 
 # Specify whether to run quality-control analyses
 quality-control:
@@ -37,6 +37,9 @@ analysis:
   allele-frequencies:
     activate: True
     cohort-column: location
+
+# Specify whether to run variant calling on whole amplicons as well as target SNPs
+whole_amplicon_calling: True
 
 # Specify whether to build jupyter results book
 build-jupyter-book: True

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -8,6 +8,7 @@ dataset = config['dataset']
 metadata = pd.read_csv(config['metadata'], sep="\t")
 plate_info = np.isin(['plate', 'well_letter', 'well_number'], metadata.columns).all()
 samples = metadata['sampleID']
+call_types = ['targets', 'amplicons'] if config['whole_amplicon_calling'] else ['targets']
 
 import os
 wkdir = os.getcwd()

--- a/workflow/notebooks/read-quality.ipynb
+++ b/workflow/notebooks/read-quality.ipynb
@@ -54,7 +54,7 @@
     "from IPython.display import display, Markdown\n",
     "display(Markdown('## MultiQC'))\n",
     "display(Markdown('MultiQC is a tool which integrates information from various tools in the workflow (Currently, it is not quite configured correctly)'))\n",
-    "display(Markdown(f'<a href={wkdir}/results/multiqc/multiqc_report.html>MultiQC report</a>'))"
+    "display(Markdown(f'<a href={wkdir}/results/qc/multiqc/multiqc_report.html>MultiQC report</a>'))"
    ]
   },
   {
@@ -70,8 +70,8 @@
     "if index_read_qc:\n",
     "    display(Markdown('## Index read QC'))\n",
     "    display(Markdown('Index reads with average quality score below 30 for a given run may be unreliable and cause demultiplexing errors.'))\n",
-    "    display(Markdown(f'<a href={wkdir}/results/index-read-qc/I1.html>Index 1 FASTQC report</a>'))\n",
-    "    display(Markdown(f'<a href={wkdir}/results/index-read-qc/I2.html>Index 2 FASTQC report</a>'))"
+    "    display(Markdown(f'<a href={wkdir}/results/qc/index-read-qc/I1.html>Index 1 FASTQC report</a>'))\n",
+    "    display(Markdown(f'<a href={wkdir}/results/qc/index-read-qc/I2.html>Index 2 FASTQC report</a>'))"
    ]
   },
   {
@@ -87,7 +87,7 @@
    "source": [
     "display(Markdown('## Sample read QC'))\n",
     "for sample in metadata.sampleID:\n",
-    "    display(Markdown(f'<a href={wkdir}/results/fastp_reports/{sample}.html>{sample} fastp report</a>'))"
+    "    display(Markdown(f'<a href={wkdir}/results/qc/fastp_reports/{sample}.html>{sample} fastp report</a>'))"
    ]
   }
  ],

--- a/workflow/rules/alignment-variantcalling.smk
+++ b/workflow/rules/alignment-variantcalling.smk
@@ -74,7 +74,7 @@ rule bam_index:
         "samtools index {input} {output} 2> {log}"
 
 
-rule mpileup_call:
+rule mpileup_call_targets:
     """
     Get pileup of reads at target loci and pipe output to bcftoolsCall
     """
@@ -83,10 +83,10 @@ rule mpileup_call:
         index = "results/alignments/{sample}.bam.bai",
         reference = config['reference-fasta']
     output:
-        calls = "results/bcfs/{sample}.calls.vcf"
+        calls = "results/vcfs/targets/{sample}.calls.vcf"
     log:
-        mpileup = "logs/mpileup/{sample}.log",
-        call = "logs/bcftools_call/{sample}.log"
+        mpileup = "logs/mpileup/targets/{sample}.log",
+        call = "logs/bcftools_call/targets/{sample}.log"
     conda:
         "../envs/AmpSeeker-cli.yaml"
     params:
@@ -96,5 +96,30 @@ rule mpileup_call:
     shell:
         """
         bcftools mpileup -Ov -f {params.ref} -R {params.regions} --max-depth {params.depth} {input.bam} 2> {log.mpileup} |
+        bcftools call -m -Ov 2> {log.call} | bcftools sort -Ov -o {output.calls} 2> {log.call}
+        """
+
+
+rule mpileup_call_amplicons:
+    """
+    Get pileup of reads at target loci and pipe output to bcftoolsCall
+    """
+    input:
+        bam = "results/alignments/{sample}.bam",
+        index = "results/alignments/{sample}.bam.bai",
+        reference = config['reference-fasta']
+    output:
+        calls = "results/vcfs/amplicons/{sample}.calls.vcf"
+    log:
+        mpileup = "logs/mpileup/amplicons/{sample}.log",
+        call = "logs/bcftools_call/amplicons/{sample}.log"
+    conda:
+        "../envs/AmpSeeker-cli.yaml"
+    params:
+        ref = config['reference-fasta'],
+        depth = 2000
+    shell:
+        """
+        bcftools mpileup -Ov -f {params.ref} --max-depth {params.depth} {input.bam} 2> {log.mpileup} |
         bcftools call -m -Ov 2> {log.call} | bcftools sort -Ov -o {output.calls} 2> {log.call}
         """

--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -48,7 +48,7 @@ rule pca:
     input:
         nb = f"{workflow.basedir}/notebooks/principal-component-analysis.ipynb",
         kernel = "results/.kernel.set",
-        vcf = expand("results/vcfs/{dataset}.merged.vcf", dataset=dataset),
+        vcf = expand("results/vcfs/targets/{dataset}.merged.vcf", dataset=dataset),
         metadata = config["metadata"],
     output:
         nb = "results/notebooks/principal-component-analysis.ipynb",
@@ -93,7 +93,7 @@ rule allele_frequencies:
         kernel = "results/.kernel.set",
         metadata = config["metadata"],
         bed = config['targets'],
-        vcf = expand("results/vcfs/{dataset}.merged.vcf", dataset=dataset),
+        vcf = expand("results/vcfs/targets/{dataset}.merged.vcf", dataset=dataset),
     output:
         nb = "results/notebooks/allele-frequencies.ipynb",
         docs_nb = "docs/ampseeker-results/notebooks/allele-frequencies.ipynb"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -45,7 +45,7 @@ def AmpSeekerOutputs(wildcards):
     
             
     if config['bcl-convert']:
-        inputs.extend(["results/index-read-qc/I1.html", "results/index-read-qc/I2.html"])
+        inputs.extend(["results/qc/index-read-qc/I1.html", "results/qc/index-read-qc/I2.html"])
 
     if plate_info:
         inputs.extend(["results/notebooks/reads-per-well.ipynb", 
@@ -71,7 +71,7 @@ def AmpSeekerOutputs(wildcards):
         inputs.extend(
             expand(
                 [
-                    "results/fastp_reports/{sample}.html",
+                    "results/qc/fastp_reports/{sample}.html",
                     "results/notebooks/read-quality.ipynb",
                     "docs/ampseeker-results/notebooks/read-quality.ipynb"
                 ],
@@ -84,7 +84,7 @@ def AmpSeekerOutputs(wildcards):
         inputs.extend(               
             expand(
                 [
-                    "results/qualimap/{sample}",
+                    "results/qc/qualimap/{sample}",
                 ],
                 sample=samples,
             )
@@ -94,7 +94,7 @@ def AmpSeekerOutputs(wildcards):
         inputs.extend(
             expand(
                 [
-                    "results/multiqc/multiqc_report.html",
+                    "results/qc/multiqc/multiqc_report.html",
                 ],
             )
         )
@@ -104,7 +104,7 @@ def AmpSeekerOutputs(wildcards):
             expand(
                 [
                     "results/alignments/bamStats/{sample}.flagstat",
-                    "results/vcfs/targets/stats/{dataset}.merged.vcf.txt",
+                    "results/qc/{dataset}.merged.vcf.txt",
                 ],
                 sample=samples, 
                 dataset=config['dataset'],

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -43,8 +43,7 @@ def AmpSeekerOutputs(wildcards):
                 ),
     )
     
-                
-
+            
     if config['bcl-convert']:
         inputs.extend(["results/index-read-qc/I1.html", "results/index-read-qc/I2.html"])
 
@@ -53,9 +52,9 @@ def AmpSeekerOutputs(wildcards):
                         "docs/ampseeker-results/notebooks/reads-per-well.ipynb"])
  
     if large_sample_size:
-        inputs.extend(expand("results/vcfs/{dataset}.complete.merge_vcfs", dataset=config['dataset']))
+        inputs.extend(expand("results/vcfs/{call_type}/{dataset}.complete.merge_vcfs", dataset=config['dataset'], call_type=call_types))
     else:
-        inputs.extend(expand("results/vcfs/{dataset}.merged.vcf", dataset=config['dataset']))
+        inputs.extend(expand("results/vcfs/{call_type}/{dataset}.merged.vcf", dataset=config['dataset'], call_type=call_types))
 
     if config['quality-control']['coverage']:
             inputs.extend(
@@ -105,7 +104,7 @@ def AmpSeekerOutputs(wildcards):
             expand(
                 [
                     "results/alignments/bamStats/{sample}.flagstat",
-                    "results/vcfs/stats/{dataset}.merged.vcf.txt",
+                    "results/vcfs/targets/stats/{dataset}.merged.vcf.txt",
                 ],
                 sample=samples, 
                 dataset=config['dataset'],

--- a/workflow/rules/qc-notebooks.smk
+++ b/workflow/rules/qc-notebooks.smk
@@ -24,7 +24,7 @@ rule read_qc:
     input:
         nb = f"{workflow.basedir}/notebooks/read-quality.ipynb",
         kernel = "results/.kernel.set",
-        fastp = expand("results/fastp_reports/{sample}.json", sample=samples),
+        fastp = expand("results/qc/fastp_reports/{sample}.json", sample=samples),
         metadata = config["metadata"],
     output:
         nb = "results/notebooks/read-quality.ipynb",

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -114,7 +114,7 @@ rule multiQC:
         expand("results/coverage/{sample}.mosdepth.global.dist.txt", sample=samples) if config['quality-control']['coverage'] else [],
         expand("results/qc/qualimap/{sample}/genome_results.txt", sample=samples) if config['quality-control']['qualimap'] else [],
     output:
-        "results/multiqc/multiqc_report.html"
+        "results/qc/multiqc/multiqc_report.html"
     params:
         extra="--config config/multiqc.yaml"
     log:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -37,7 +37,7 @@ rule multiQC:
     input:
         expand("results/fastp_reports/{sample}.json", sample=samples) if config['quality-control']['fastp'] else [],
         expand("results/alignments/bamStats/{sample}.flagstat", sample=samples) if config['quality-control']['stats'] else [],
-        expand("results/vcfs/stats/{dataset}.merged.vcf.txt", dataset=dataset) if config['quality-control']['stats'] else [],
+        expand("results/vcfs/targets/stats/{dataset}.merged.vcf.txt", dataset=dataset) if config['quality-control']['stats'] else [],
         expand("results/coverage/{sample}.per-base.bed.gz", sample=samples) if config['quality-control']['coverage'] else [],
         expand("results/coverage/{sample}.mosdepth.summary.txt", sample=samples) if config['quality-control']['coverage'] else [],
         expand("results/coverage/{sample}.mosdepth.global.dist.txt", sample=samples) if config['quality-control']['coverage'] else [],
@@ -113,9 +113,9 @@ rule qualimap:
 
 rule vcf_stats:
     input:
-        vcf = "results/vcfs/{dataset}.merged.vcf"
+        vcf = "results/vcfs/targets/{dataset}.merged.vcf"
     output:
-        stats = "results/vcfs/stats/{dataset}.merged.vcf.txt"
+        stats = "results/vcfs/targets/stats/{dataset}.merged.vcf.txt"
     log:
         "logs/vcfStats/{dataset}.log"
     conda:

--- a/workflow/rules/utilities.smk
+++ b/workflow/rules/utilities.smk
@@ -5,23 +5,23 @@ Kept in a separate rule file due to maintain visibility of the main, analysis ru
 
 rule bgzip:
     input:
-        "results/bcfs/{sample}.calls.vcf",    
+        vcf = "results/vcfs/{call_type}/{sample}.calls.vcf",    
     output:
-        "results/bcfs/{sample}.calls.vcf.gz",
+        vcfgz = "results/vcfs/{call_type}/{sample}.calls.vcf.gz",
     log:
-        "logs/bgzip/{sample}.log",
+        log = "logs/bgzip/{call_type}/{sample}.log",
     wrapper:
         "v1.17.4-17-g62b55d45/bio/bgzip"
 
 rule tabix:
     input:
-        calls = "results/bcfs/{sample}.calls.vcf.gz",    
+        calls = "results/vcfs/{call_type}/{sample}.calls.vcf.gz",    
     output:
-        calls_tbi = "results/bcfs/{sample}.calls.vcf.gz.tbi",
+        calls_tbi = "results/vcfs/{call_type}/{sample}.calls.vcf.gz.tbi",
     conda:
         "../envs/AmpSeeker-cli.yaml"
     log:
-        "logs/tabix/{sample}.log",
+        "logs/tabix/{call_type}/{sample}.log",
     shell:
         """
         tabix {input.calls} 2> {log}
@@ -29,44 +29,44 @@ rule tabix:
 
 rule bcftools_merge:
     input:
-        bcfs = expand("results/bcfs/{sample}.calls.vcf.gz", sample=samples),
-        idx = expand("results/bcfs/{sample}.calls.vcf.gz.tbi", sample=samples)
+        vcfs = expand("results/vcfs/{{call_type}}/{sample}.calls.vcf.gz", sample=samples),
+        idx = expand("results/vcfs/{{call_type}}/{sample}.calls.vcf.gz.tbi", sample=samples)
     output:
-        vcf = "results/vcfs/{dataset}.merged.vcf",
+        vcf = "results/vcfs/{call_type}/{dataset}.merged.vcf",
     log:
-        "logs/bcftools/merge_{dataset}.log",
+        "logs/bcftools/{call_type}/merge_{dataset}.log",
     conda:
         "../envs/AmpSeeker-cli.yaml"
     threads: 12
     shell:
         """
-        bcftools merge --threads {threads} -o {output.vcf} -O v {input.bcfs} --force-samples 2> {log}
+        bcftools merge --threads {threads} -o {output.vcf} -O v {input.vcfs} --force-samples 2> {log}
         """
 
 rule bcftools_merge1:
     input:
-        bcfs = expand("results/bcfs/{sample}.calls.vcf.gz", sample=samples1),
-        idx = expand("results/bcfs/{sample}.calls.vcf.gz.tbi", sample=samples1)
+        vcfs = expand("results/vcfs/{call_type}/{sample}.calls.vcf.gz", sample=samples1),
+        idx = expand("results/vcfs/{call_type}/{sample}.calls.vcf.gz.tbi", sample=samples1)
     output:
-        vcf = "results/vcfs/{dataset}.1.vcf",
+        vcf = "results/vcfs/{call_type}/{dataset}.1.vcf",
     log:
-        "logs/bcftools/merge1_{dataset}.log",
+        "logs/bcftools/{call_type}/merge1_{dataset}.log",
     conda:
         "../envs/AmpSeeker-cli.yaml"
     threads: 12
     shell:
         """
-        bcftools merge --threads {threads} -o {output.vcf} -O v {input.bcfs} 2> {log}
+        bcftools merge --threads {threads} -o {output.vcf} -O v {input.vcfs} 2> {log}
         """
 
 rule bcftools_merge2:
     input:
-        vcfs = expand("results/bcfs/{sample}.calls.vcf.gz", sample=samples2),
-        idx = expand("results/bcfs/{sample}.calls.vcf.gz.tbi", sample=samples2)
+        vcfs = expand("results/vcfs/{call_type}/{sample}.calls.vcf.gz", sample=samples2),
+        idx = expand("results/vcfs/{call_type}/{sample}.calls.vcf.gz.tbi", sample=samples2)
     output:
-        vcf = "results/vcfs/{dataset}.2.vcf",
+        vcf = "results/vcfs/{call_type}/{dataset}.2.vcf",
     log:
-        "logs/bcftools/merge2_{dataset}.log",
+        "logs/bcftools/{call_type}/merge2_{dataset}.log",
     conda:
         "../envs/AmpSeeker-cli.yaml"
     threads: 12
@@ -77,21 +77,21 @@ rule bcftools_merge2:
 
 rule bgzip2:
     input:
-        "results/{ref}/vcfs/{dataset}.{n}.vcf",
+        vcf="results/vcfs/{call_type}/{dataset}.{n}.vcf",
     output:
-        "results/{ref}/vcfs/{dataset}.{n}.vcf.gz",
+        vcfgz="results/vcfs/{call_type}/{dataset}.{n, [0-9]}.vcf.gz",
     log:
-        "logs/bgzip/{dataset}.{n}_{ref}.log",
+        "logs/bgzip/{call_type}/{dataset}.{n}.log",
     wrapper:
         "v1.17.4-17-g62b55d45/bio/bgzip"
 
 rule tabix2:
     input:
-        vcfgz = "results/vcfs/{dataset}.{n}.vcf.gz",
+        vcfgz = "results/vcfs/{call_type}/{dataset}.{n}.vcf.gz",
     output:
-        tbi = "results/vcfs/{dataset}.{n}.vcf.gz.tbi"
+        tbi = "results/vcfs/{call_type}/{dataset}.{n, [/d]}.vcf.gz.tbi"
     log:
-        "logs/tabix/{dataset}.{n}.log",
+        "logs/tabix/{call_type}/{dataset}.{n}.log",
     conda:
         "../envs/AmpSeeker-cli.yaml"
     shell:
@@ -101,13 +101,13 @@ rule tabix2:
 
 rule bcftools_merge3:
     input:
-        vcf = expand("results/vcfs/{{dataset}}.{n}.vcf.gz", n=[1,2]),
-        tbi = expand("results/vcfs/{{dataset}}.{n}.vcf.gz.tbi", n=[1,2]),
+        vcf = expand("results/vcfs/{{call_type}}/{{dataset}}.{n}.vcf.gz", n=[1,2]),
+        tbi = expand("results/vcfs/{{call_type}}/{{dataset}}.{n}.vcf.gz.tbi", n=[1,2]),
     output:
-        vcf = "results/vcfs/{dataset}_merged.vcf",
-        holder = touch("results/vcfs/.complete.{dataset}.merge_vcfs")
+        vcf = "results/vcfs/{call_type}/{dataset}.merged.vcf",
+        holder = touch("results/vcfs/{call_type}/.complete.{dataset}.merge_vcfs")
     log:
-        "logs/bcftools/merge3_{dataset}.log",
+        "logs/bcftools/{call_type}/merge3_{dataset}.log",
     conda:
         "../envs/AmpSeeker-cli.yaml"
     shell:


### PR DESCRIPTION
- this PR addresses #77 giving an option to call across whole amplicons 

- and moves all qc results folders into a folder `results/qc` for neatness. 