### PR TITLE
Bug fixes

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,16 +1,15 @@
 # This file should contain everything to configure the workflow on a global scale.
 # In case of sample based data, it should be complemented by a samples.tsv file that contains
 # one row per sample. It can be parsed easily via pandas.
-dataset: ampseq-vigg01
+dataset: ampseq-colony
 panel: ag-vampir
 metadata: config/metadata.tsv
 cohort-columns:
-  - taxon
-  - location
+  - strain
 targets: config/ag-vampir.bed
 
 # Directory of Illumina Miseq Run, can be empty 
-illumina-dir: resources/230629_M05658_0009_000000000-DL7P9/
+illumina-dir: resources/240909_M05658_0026_000000000-L7LFB
 
 # Specify whether reference  provided is amplicon or wholegenome sequence data
 # Genome fasta reference files
@@ -18,10 +17,11 @@ reference-name: AgamP4
 reference-fasta: resources/reference/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa
 reference-gff3: resources/reference/Anopheles-gambiae-PEST_BASEFEATURES_AgamP4.12.gff3
 reference-snpeffdb: Anopheles_gambiae
+custom-snpeffdb: False
 
 # Specify whether to convert bcl files to fastq
 # or whether we provide fastq data in the metadata / or auto naming 
-bcl-convert: False
+bcl-convert: True
 fastq:
   auto: True
 

--- a/workflow/notebooks/ag-vampir/species-id.ipynb
+++ b/workflow/notebooks/ag-vampir/species-id.ipynb
@@ -80,6 +80,8 @@
    },
    "outputs": [],
    "source": [
+    "cohort_col = cohort_cols.split(',')[0]\n",
+    "\n",
     "metadata = pd.read_csv(metadata_path , sep=\"\\t\", index_col=0)\n",
     "targets = pd.read_csv(bed_targets_path, sep=\"\\t\", header=None)\n",
     "targets.columns = ['contig', 'start', 'end', 'amplicon', 'mutation']\n",
@@ -158,7 +160,7 @@
     "aims = mean_aims.loc[metadata.set_index('sampleID').index]\n",
     "metadata = metadata.assign(mean_aim_genotype=aims.values)\n",
     "\n",
-    "fig = px.histogram(metadata, nbins=100, x='mean_aim_genotype', color='location', width=750, height=400, template='plotly_white', title='AIM genotype distribution')\n",
+    "fig = px.histogram(metadata, nbins=100, x='mean_aim_genotype', color=cohort_col, width=750, height=400, template='plotly_white', title='AIM genotype distribution')\n",
     "fig.show()"
    ]
   },

--- a/workflow/notebooks/allele-frequencies.ipynb
+++ b/workflow/notebooks/allele-frequencies.ipynb
@@ -233,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "19a63cb1",
    "metadata": {
     "scrolled": false,
@@ -241,30 +241,7 @@
      "remove-input"
     ]
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/snagi/miniconda3/lib/python3.11/site-packages/allel/io/vcf_read.py:1732: UserWarning: invalid INFO header: '##INFO=<ID=VDB,Number=1,Type=Float,Description=\"Variant Distance Bias for filtering splice-site artefacts in RNA-seq data (bigger is better)\",Version=\"3\">\\n'\n",
-      "  warnings.warn('invalid INFO header: %r' % header)\n"
-     ]
-    },
-    {
-     "ename": "IndexError",
-     "evalue": "index 2 is out of bounds for axis 1 with size 2",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[11], line 6\u001b[0m\n\u001b[1;32m      3\u001b[0m frq_dfs \u001b[38;5;241m=\u001b[39m []\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m cohort_col \u001b[38;5;129;01min\u001b[39;00m cohort_cols:\n\u001b[0;32m----> 6\u001b[0m     freq_df \u001b[38;5;241m=\u001b[39m \u001b[43mcalculate_frequencies_cohort\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      7\u001b[0m \u001b[43m        \u001b[49m\u001b[43msnp_df\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43msnp_df\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m      8\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmetadata\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmetadata\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m      9\u001b[0m \u001b[43m        \u001b[49m\u001b[43mgeno\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mgeno\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m     10\u001b[0m \u001b[43m        \u001b[49m\u001b[43mcohort_col\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcohort_col\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     11\u001b[0m \u001b[43m        \u001b[49m\u001b[43maf_filter\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m     12\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmissense_filter\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\n\u001b[1;32m     13\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     14\u001b[0m     frq_dfs\u001b[38;5;241m.\u001b[39mappend(freq_df\u001b[38;5;241m.\u001b[39mreset_index(drop\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m))\n\u001b[1;32m     16\u001b[0m     plot_allele_frequencies(\n\u001b[1;32m     17\u001b[0m         df\u001b[38;5;241m=\u001b[39mfreq_df\u001b[38;5;241m.\u001b[39mfilter(like\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mfrq_\u001b[39m\u001b[38;5;124m'\u001b[39m),\n\u001b[1;32m     18\u001b[0m         cohort_col\u001b[38;5;241m=\u001b[39mcohort_col\n\u001b[1;32m     19\u001b[0m     )\n",
-      "Cell \u001b[0;32mIn[1], line 116\u001b[0m, in \u001b[0;36mcalculate_frequencies_cohort\u001b[0;34m(snp_df, metadata, geno, cohort_col, af_filter, missense_filter)\u001b[0m\n\u001b[1;32m    114\u001b[0m     alt_idx \u001b[38;5;241m=\u001b[39m row[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124malt_index\u001b[39m\u001b[38;5;124m'\u001b[39m]\n\u001b[1;32m    115\u001b[0m     total_counts\u001b[38;5;241m.\u001b[39mappend(ac[coh][var_idx,:]\u001b[38;5;241m.\u001b[39msum())\n\u001b[0;32m--> 116\u001b[0m     alt_counts\u001b[38;5;241m.\u001b[39mappend(\u001b[43mac\u001b[49m\u001b[43m[\u001b[49m\u001b[43mcoh\u001b[49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[43mvar_idx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43malt_idx\u001b[49m\u001b[43m]\u001b[49m)\n\u001b[1;32m    118\u001b[0m df\u001b[38;5;241m.\u001b[39mloc[:, \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcount_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcoh\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39marray(alt_counts)\n\u001b[1;32m    119\u001b[0m df\u001b[38;5;241m.\u001b[39mloc[:, \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mfrq_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcoh\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mround(np\u001b[38;5;241m.\u001b[39marray(alt_counts)\u001b[38;5;241m/\u001b[39mnp\u001b[38;5;241m.\u001b[39marray(total_counts), \u001b[38;5;241m3\u001b[39m)\n",
-      "File \u001b[0;32m~/miniconda3/lib/python3.11/site-packages/allel/model/ndarray.py:2624\u001b[0m, in \u001b[0;36mAlleleCountsArray.__getitem__\u001b[0;34m(self, item)\u001b[0m\n\u001b[1;32m   2623\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__getitem__\u001b[39m(\u001b[38;5;28mself\u001b[39m, item):\n\u001b[0;32m-> 2624\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mindex_allele_counts_array\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mitem\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mtype\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/miniconda3/lib/python3.11/site-packages/allel/model/generic.py:143\u001b[0m, in \u001b[0;36mindex_allele_counts_array\u001b[0;34m(ac, item, cls)\u001b[0m\n\u001b[1;32m    140\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mindex_allele_counts_array\u001b[39m(ac, item, \u001b[38;5;28mcls\u001b[39m):\n\u001b[1;32m    141\u001b[0m \n\u001b[1;32m    142\u001b[0m     \u001b[38;5;66;03m# apply indexing operation on underlying values\u001b[39;00m\n\u001b[0;32m--> 143\u001b[0m     out \u001b[38;5;241m=\u001b[39m \u001b[43mac\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvalues\u001b[49m\u001b[43m[\u001b[49m\u001b[43mitem\u001b[49m\u001b[43m]\u001b[49m\n\u001b[1;32m    145\u001b[0m     \u001b[38;5;66;03m# decide whether to wrap the result as HaplotypeArray\u001b[39;00m\n\u001b[1;32m    146\u001b[0m     wrap_array \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    147\u001b[0m         \u001b[38;5;28mhasattr\u001b[39m(out, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mndim\u001b[39m\u001b[38;5;124m'\u001b[39m) \u001b[38;5;129;01mand\u001b[39;00m out\u001b[38;5;241m.\u001b[39mndim \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m2\u001b[39m \u001b[38;5;129;01mand\u001b[39;00m  \u001b[38;5;66;03m# dimensionality preserved\u001b[39;00m\n\u001b[1;32m    148\u001b[0m         ac\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m1\u001b[39m] \u001b[38;5;241m==\u001b[39m out\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m1\u001b[39m] \u001b[38;5;129;01mand\u001b[39;00m  \u001b[38;5;66;03m# number of alleles preserved\u001b[39;00m\n\u001b[1;32m    149\u001b[0m         \u001b[38;5;129;01mnot\u001b[39;00m contains_newaxis(item)\n\u001b[1;32m    150\u001b[0m     )\n",
-      "\u001b[0;31mIndexError\u001b[0m: index 2 is out of bounds for axis 1 with size 2"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "snp_df, geno = vcf_to_snp_dataframe(vcf_path, metadata)\n",
     "\n",
@@ -297,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "72ffa152",
    "metadata": {
     "scrolled": false,
@@ -305,19 +282,7 @@
      "remove-input"
     ]
    },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'snp_df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[8], line 4\u001b[0m\n\u001b[1;32m      1\u001b[0m pd\u001b[38;5;241m.\u001b[39mset_option(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdisplay.max_rows\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;241m200\u001b[39m)\n\u001b[1;32m      2\u001b[0m pd\u001b[38;5;241m.\u001b[39mset_option(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mdisplay.max_columns\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;241m100\u001b[39m)\n\u001b[0;32m----> 4\u001b[0m snp_df \u001b[38;5;241m=\u001b[39m pd\u001b[38;5;241m.\u001b[39mconcat([\u001b[43msnp_df\u001b[49m] \u001b[38;5;241m+\u001b[39m frq_dfs, axis\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m)\n\u001b[1;32m      5\u001b[0m snp_df\u001b[38;5;241m.\u001b[39mto_csv(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mwkdir\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m/results/snp_frequencies_summary.tsv\u001b[39m\u001b[38;5;124m\"\u001b[39m, sep\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;130;01m\\t\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      6\u001b[0m snp_df\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'snp_df' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pd.set_option(\"display.max_rows\", 200)\n",
     "pd.set_option('display.max_columns', 100)\n",

--- a/workflow/notebooks/allele-frequencies.ipynb
+++ b/workflow/notebooks/allele-frequencies.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "cd3f429b",
    "metadata": {
     "tags": [
@@ -20,9 +20,7 @@
     "    \"\"\"\n",
     "    Load VCF and filter poor-quality samples\n",
     "    \"\"\"\n",
-    "    \n",
-    "    sampleIDs = metadata.sampleID.to_list()\n",
-    "    \n",
+    "      \n",
     "    # load vcf and get genotypes and positions\n",
     "    vcf = allel.read_vcf(vcf_path, fields='*')\n",
     "    samples = vcf['samples']\n",
@@ -74,6 +72,7 @@
     "            anns.append(ann_value)\n",
     "\n",
     "    return np.array(anns)\n",
+    "\n",
     "def vcf_to_snp_dataframe(vcf_path, metadata):\n",
     "\n",
     "    geno, pos, contig, samples, ref, alt, ann = load_vcf(vcf_path=vcf_path, metadata=metadata)\n",
@@ -117,10 +116,8 @@
     "    for coh in cohs:\n",
     "        coh_dict[coh] = np.where(metadata[cohort_col] == coh)[0]\n",
     "    \n",
-    "    tot_ac = geno.count_alleles()\n",
-    "\n",
     "    # get allele counts for each population\n",
-    "    ac = geno.count_alleles_subpops(coh_dict)\n",
+    "    ac = geno.count_alleles_subpops(coh_dict, max_allele=3)\n",
     "    \n",
     "    for coh in cohs:\n",
     "        total_counts = []\n",
@@ -175,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "d4571035",
    "metadata": {
     "tags": [
@@ -185,11 +182,11 @@
    },
    "outputs": [],
    "source": [
-    "dataset = 'ampseq-vigg-002'\n",
+    "dataset = 'ampseq-colony'\n",
     "metadata_path = \"../../results/config/metadata.qcpass.tsv\"\n",
-    "cohort_cols = 'taxon,location'\n",
+    "cohort_cols = 'strain' #taxon,location'\n",
     "bed_path = \"../../config/ag-vampir.bed\"\n",
-    "vcf_path = \"../../results/vcfs/targets/ampseq-vigg002.annot.vcf\"\n",
+    "vcf_path = \"../../results/vcfs/targets/ampseq-colony.annot.vcf\"\n",
     "wkdir = \"../..\""
    ]
   },
@@ -209,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "ee8c132c",
    "metadata": {
     "tags": [
@@ -236,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "19a63cb1",
    "metadata": {
     "scrolled": false,
@@ -244,7 +241,30 @@
      "remove-input"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/snagi/miniconda3/lib/python3.11/site-packages/allel/io/vcf_read.py:1732: UserWarning: invalid INFO header: '##INFO=<ID=VDB,Number=1,Type=Float,Description=\"Variant Distance Bias for filtering splice-site artefacts in RNA-seq data (bigger is better)\",Version=\"3\">\\n'\n",
+      "  warnings.warn('invalid INFO header: %r' % header)\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "index 2 is out of bounds for axis 1 with size 2",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[11], line 6\u001b[0m\n\u001b[1;32m      3\u001b[0m frq_dfs \u001b[38;5;241m=\u001b[39m []\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m cohort_col \u001b[38;5;129;01min\u001b[39;00m cohort_cols:\n\u001b[0;32m----> 6\u001b[0m     freq_df \u001b[38;5;241m=\u001b[39m \u001b[43mcalculate_frequencies_cohort\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      7\u001b[0m \u001b[43m        \u001b[49m\u001b[43msnp_df\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43msnp_df\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m      8\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmetadata\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmetadata\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m      9\u001b[0m \u001b[43m        \u001b[49m\u001b[43mgeno\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mgeno\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m     10\u001b[0m \u001b[43m        \u001b[49m\u001b[43mcohort_col\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcohort_col\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     11\u001b[0m \u001b[43m        \u001b[49m\u001b[43maf_filter\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m     12\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmissense_filter\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\n\u001b[1;32m     13\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     14\u001b[0m     frq_dfs\u001b[38;5;241m.\u001b[39mappend(freq_df\u001b[38;5;241m.\u001b[39mreset_index(drop\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m))\n\u001b[1;32m     16\u001b[0m     plot_allele_frequencies(\n\u001b[1;32m     17\u001b[0m         df\u001b[38;5;241m=\u001b[39mfreq_df\u001b[38;5;241m.\u001b[39mfilter(like\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mfrq_\u001b[39m\u001b[38;5;124m'\u001b[39m),\n\u001b[1;32m     18\u001b[0m         cohort_col\u001b[38;5;241m=\u001b[39mcohort_col\n\u001b[1;32m     19\u001b[0m     )\n",
+      "Cell \u001b[0;32mIn[1], line 116\u001b[0m, in \u001b[0;36mcalculate_frequencies_cohort\u001b[0;34m(snp_df, metadata, geno, cohort_col, af_filter, missense_filter)\u001b[0m\n\u001b[1;32m    114\u001b[0m     alt_idx \u001b[38;5;241m=\u001b[39m row[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124malt_index\u001b[39m\u001b[38;5;124m'\u001b[39m]\n\u001b[1;32m    115\u001b[0m     total_counts\u001b[38;5;241m.\u001b[39mappend(ac[coh][var_idx,:]\u001b[38;5;241m.\u001b[39msum())\n\u001b[0;32m--> 116\u001b[0m     alt_counts\u001b[38;5;241m.\u001b[39mappend(\u001b[43mac\u001b[49m\u001b[43m[\u001b[49m\u001b[43mcoh\u001b[49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[43mvar_idx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43malt_idx\u001b[49m\u001b[43m]\u001b[49m)\n\u001b[1;32m    118\u001b[0m df\u001b[38;5;241m.\u001b[39mloc[:, \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcount_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcoh\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39marray(alt_counts)\n\u001b[1;32m    119\u001b[0m df\u001b[38;5;241m.\u001b[39mloc[:, \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mfrq_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcoh\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mround(np\u001b[38;5;241m.\u001b[39marray(alt_counts)\u001b[38;5;241m/\u001b[39mnp\u001b[38;5;241m.\u001b[39marray(total_counts), \u001b[38;5;241m3\u001b[39m)\n",
+      "File \u001b[0;32m~/miniconda3/lib/python3.11/site-packages/allel/model/ndarray.py:2624\u001b[0m, in \u001b[0;36mAlleleCountsArray.__getitem__\u001b[0;34m(self, item)\u001b[0m\n\u001b[1;32m   2623\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__getitem__\u001b[39m(\u001b[38;5;28mself\u001b[39m, item):\n\u001b[0;32m-> 2624\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mindex_allele_counts_array\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mitem\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mtype\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/miniconda3/lib/python3.11/site-packages/allel/model/generic.py:143\u001b[0m, in \u001b[0;36mindex_allele_counts_array\u001b[0;34m(ac, item, cls)\u001b[0m\n\u001b[1;32m    140\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mindex_allele_counts_array\u001b[39m(ac, item, \u001b[38;5;28mcls\u001b[39m):\n\u001b[1;32m    141\u001b[0m \n\u001b[1;32m    142\u001b[0m     \u001b[38;5;66;03m# apply indexing operation on underlying values\u001b[39;00m\n\u001b[0;32m--> 143\u001b[0m     out \u001b[38;5;241m=\u001b[39m \u001b[43mac\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvalues\u001b[49m\u001b[43m[\u001b[49m\u001b[43mitem\u001b[49m\u001b[43m]\u001b[49m\n\u001b[1;32m    145\u001b[0m     \u001b[38;5;66;03m# decide whether to wrap the result as HaplotypeArray\u001b[39;00m\n\u001b[1;32m    146\u001b[0m     wrap_array \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    147\u001b[0m         \u001b[38;5;28mhasattr\u001b[39m(out, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mndim\u001b[39m\u001b[38;5;124m'\u001b[39m) \u001b[38;5;129;01mand\u001b[39;00m out\u001b[38;5;241m.\u001b[39mndim \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m2\u001b[39m \u001b[38;5;129;01mand\u001b[39;00m  \u001b[38;5;66;03m# dimensionality preserved\u001b[39;00m\n\u001b[1;32m    148\u001b[0m         ac\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m1\u001b[39m] \u001b[38;5;241m==\u001b[39m out\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m1\u001b[39m] \u001b[38;5;129;01mand\u001b[39;00m  \u001b[38;5;66;03m# number of alleles preserved\u001b[39;00m\n\u001b[1;32m    149\u001b[0m         \u001b[38;5;129;01mnot\u001b[39;00m contains_newaxis(item)\n\u001b[1;32m    150\u001b[0m     )\n",
+      "\u001b[0;31mIndexError\u001b[0m: index 2 is out of bounds for axis 1 with size 2"
+     ]
+    }
+   ],
    "source": [
     "snp_df, geno = vcf_to_snp_dataframe(vcf_path, metadata)\n",
     "\n",
@@ -277,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "72ffa152",
    "metadata": {
     "scrolled": false,
@@ -285,7 +305,19 @@
      "remove-input"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'snp_df' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[8], line 4\u001b[0m\n\u001b[1;32m      1\u001b[0m pd\u001b[38;5;241m.\u001b[39mset_option(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdisplay.max_rows\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;241m200\u001b[39m)\n\u001b[1;32m      2\u001b[0m pd\u001b[38;5;241m.\u001b[39mset_option(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mdisplay.max_columns\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;241m100\u001b[39m)\n\u001b[0;32m----> 4\u001b[0m snp_df \u001b[38;5;241m=\u001b[39m pd\u001b[38;5;241m.\u001b[39mconcat([\u001b[43msnp_df\u001b[49m] \u001b[38;5;241m+\u001b[39m frq_dfs, axis\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m)\n\u001b[1;32m      5\u001b[0m snp_df\u001b[38;5;241m.\u001b[39mto_csv(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mwkdir\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m/results/snp_frequencies_summary.tsv\u001b[39m\u001b[38;5;124m\"\u001b[39m, sep\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;130;01m\\t\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      6\u001b[0m snp_df\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'snp_df' is not defined"
+     ]
+    }
+   ],
    "source": [
     "pd.set_option(\"display.max_rows\", 200)\n",
     "pd.set_option('display.max_columns', 100)\n",
@@ -347,9 +379,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "AmpSeq_python",
+   "display_name": "base",
    "language": "python",
-   "name": "ampseq_python"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -361,7 +393,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/workflow/notebooks/run-statistics.ipynb
+++ b/workflow/notebooks/run-statistics.ipynb
@@ -31,8 +31,6 @@
     "wkdir = '../..'\n",
     "plate_info = False\n",
     "cohort_cols = 'location,taxon'\n",
-    "cohort_col = cohort_cols.split(\",\")[0]\n",
-    "config_path = '../../config/config.yaml'\n",
     "\n",
     "pd.set_option(\"display.max_rows\", None)\n",
     "pd.set_option(\"display.max_columns\", None)\n",
@@ -58,6 +56,8 @@
    },
    "outputs": [],
    "source": [
+    "cohort_col = cohort_cols.split(\",\")[0]\n",
+    "\n",
     "# load panel metadata\n",
     "if metadata_path.endswith('.xlsx'):\n",
     "    metadata = pd.read_excel(metadata_path, engine='openpyxl')\n",
@@ -69,7 +69,7 @@
     "    raise ValueError(\"Metadata file must be .xlsx or .csv\")\n",
     "\n",
     "demultiplex_data = pd.read_csv(\n",
-    "    f\"{wkdir}/resources/bcl_output/Reports/Demultiplex_Stats.csv\"\n",
+    "    f\"{wkdir}/results/bcl_output/Reports/Demultiplex_Stats.csv\"\n",
     ").rename(columns={'# Reads':'n_reads', 'SampleID':'sampleID'})"
    ]
   },

--- a/workflow/notebooks/sample-quality-control.ipynb
+++ b/workflow/notebooks/sample-quality-control.ipynb
@@ -33,6 +33,8 @@
     "bed_targets_path = \"../../config/ag-vampir.bed\"\n",
     "vcf_path = \"../../results/vcfs/targets/ampseq-vigg-01.annot.vcf\"\n",
     "wkdir = \"../..\"\n",
+    "cohort_cols = 'strain'\n",
+    "panel = 'ag-vampir'\n",
     "\n",
     "sample_total_reads_threshold = 250\n",
     "amplicon_total_reads_threshold = 1000"
@@ -60,6 +62,7 @@
    },
    "outputs": [],
    "source": [
+    "cohort_col = cohort_cols.split(',')[0]\n",
     "metadata = pd.read_csv(metadata_path , sep=\"\\t\")\n",
     "\n",
     "panel_metadata = pd.read_csv(\n",
@@ -99,6 +102,7 @@
    },
    "outputs": [],
    "source": [
+    "\n",
     "target_covs = []\n",
     "x_ratios = []\n",
     "for sample in metadata.sampleID:\n",
@@ -107,8 +111,9 @@
     "    target_covs.append(target_cov)\n",
     "    \n",
     "    # x-autosome ratio\n",
-    "    contig_depth = target_cov.groupby('contig').agg({'depth':'sum'})\n",
-    "    x_ratios.append((contig_depth.loc[['2L', '2R', '3L', '3R']].sum() / contig_depth.loc['X']).iloc[0])\n",
+    "    if panel == 'ag-vampir':\n",
+    "        contig_depth = target_cov.groupby('contig').agg({'depth':'sum'})\n",
+    "        x_ratios.append((contig_depth.loc[['2L', '2R', '3L', '3R']].sum() / contig_depth.loc['X']).iloc[0])\n",
     "    \n",
     "target_cov_df = pd.concat(target_covs, axis=0)\n",
     "target_cov_df = target_cov_df.merge(panel_metadata, how='left', on=['contig', 'start', 'end', 'amplicon'])\n",
@@ -150,14 +155,6 @@
    "source": [
     "#### Total reads per target SNP"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6375455d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -218,8 +215,10 @@
    },
    "outputs": [],
    "source": [
-    "exclude_samples_missing_calls = samples[(geno.is_missing().sum(axis=0) > 40)]\n",
-    "print(f\"{len(exclude_samples_missing_calls)} samples have more than 40 missing calls overall out of all possible target SNPs\")\n",
+    "min_missing_calls = int(panel_metadata.shape[0] / 2)\n",
+    "\n",
+    "exclude_samples_missing_calls = samples[(geno.is_missing().sum(axis=0) > min_missing_calls)]\n",
+    "print(f\"{len(exclude_samples_missing_calls)} samples have more than {min_missing_calls} missing calls overall out of all possible target SNPs\")\n",
     "\n",
     "a = exclude_samples_missing_calls\n",
     "b = exclude_samples_depth\n",
@@ -235,7 +234,7 @@
    "id": "5d5c9601",
    "metadata": {},
    "source": [
-    "### Autosome / Sex chromosome coverage ratios\n",
+    "### Autosome / Sex chromosome coverage ratios (ag-vampir only)\n",
     "\n",
     "Females will have a lower ratio of autosomes:x, and males will have a higher ratio. Its not clear whether we can use this yet to sex samples."
    ]
@@ -251,12 +250,13 @@
    },
    "outputs": [],
    "source": [
-    "x_ratio_df = pd.DataFrame({'sampleID':metadata.sampleID, 'x_ratio':x_ratios})\n",
-    "x_ratio_df = x_ratio_df.query(\"sampleID not in @exclude_samples_depth\")\n",
+    "if panel == 'ag-vampir':\n",
+    "    x_ratio_df = pd.DataFrame({'sampleID':metadata.sampleID, 'x_ratio':x_ratios})\n",
+    "    x_ratio_df = x_ratio_df.query(\"sampleID not in @exclude_samples_depth\")\n",
     "\n",
-    "fig = px.histogram(x_ratio_df, x='x_ratio', color='sampleID', template='simple_white', nbins=1000, width=800, height=300)\n",
-    "fig.update_xaxes(range=(0,20), title=dict(text='Autosome / X depth ratio'))\n",
-    "fig.show()"
+    "    fig = px.histogram(x_ratio_df, x='x_ratio', color='sampleID', template='simple_white', nbins=1000, width=800, height=300)\n",
+    "    fig.update_xaxes(range=(0,20), title=dict(text='Autosome / X depth ratio'))\n",
+    "    fig.show()"
    ]
   },
   {
@@ -292,7 +292,7 @@
     "    het_df, \n",
     "    x='sampleID', \n",
     "    y='heterozygosity', \n",
-    "    color='location', \n",
+    "    color=cohort_col, \n",
     "    template='simple_white', \n",
     "    title=\"Individual sample heterozygosity\", \n",
     "    height=400,\n",
@@ -302,7 +302,7 @@
     "fig2  = px.histogram(\n",
     "    het_df, \n",
     "    x='heterozygosity', \n",
-    "    color='location', \n",
+    "    color=cohort_col, \n",
     "    template='simple_white', \n",
     "    title=\"Histogram of sample heterozygosity\", \n",
     "    height=400,\n",
@@ -339,8 +339,8 @@
     "iqr_multiplier = 2.5 # determines how strict we are in throwing out outliers \n",
     "\n",
     "exclude_samples_heterozygosity = []\n",
-    "for coh in het_df.location.unique():\n",
-    "    df = het_df.query(\"location == @coh\")\n",
+    "for coh in het_df[cohort_col].unique():\n",
+    "    df = het_df.query(f\"{cohort_col} == @coh\")\n",
     "    hets = df.heterozygosity\n",
     "    \n",
     "    threshold = np.nanquantile(hets, 0.75) + (iqr_multiplier * iqr(hets, nan_policy='omit'))\n",
@@ -373,9 +373,9 @@
    "outputs": [],
    "source": [
     "exclude_samples = np.unique(exclude_samples_depth.to_list() + exclude_samples_heterozygosity + list(exclude_samples_missing_calls))\n",
-    "removed_metadata = metadata.query(\"sampleID in @exclude_samples\").location.value_counts().to_frame().reset_index()\n",
+    "removed_metadata = metadata.query(\"sampleID in @exclude_samples\")[cohort_col].value_counts().to_frame().reset_index()\n",
     "\n",
-    "removed_metadata = removed_metadata.set_index('location').T\n",
+    "removed_metadata = removed_metadata.set_index(cohort_col).T\n",
     "tot = removed_metadata.sum(axis=1)\n",
     "removed_metadata = removed_metadata.assign(total=tot).T\n",
     "\n",

--- a/workflow/notebooks/snp-dataframe.ipynb
+++ b/workflow/notebooks/snp-dataframe.ipynb
@@ -212,13 +212,13 @@
     }
    ],
    "source": [
-    "vcf_df = vcf_to_excel(\n",
-    "    vcf_path=f\"{wkdir}/results/vcfs/amplicons/{dataset}.annot.vcf\",\n",
-    "    excel_path=f\"{wkdir}/results/vcfs/amplicons/{dataset}-snps.xlsx\",\n",
-    "    convert_genotypes=False,\n",
-    "    split_multiallelic=False\n",
-    ")\n",
-    "vcf_df"
+    "# vcf_df = vcf_to_excel(\n",
+    "#     vcf_path=f\"{wkdir}/results/vcfs/amplicons/{dataset}.annot.vcf\",\n",
+    "#     excel_path=f\"{wkdir}/results/vcfs/amplicons/{dataset}-snps.xlsx\",\n",
+    "#     convert_genotypes=False,\n",
+    "#     split_multiallelic=False\n",
+    "# )\n",
+    "# vcf_df"
    ]
   },
   {
@@ -236,7 +236,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vcf_df"
+    "# vcf_df"
    ]
   },
   {

--- a/workflow/rules/ag-vampir.smk
+++ b/workflow/rules/ag-vampir.smk
@@ -16,10 +16,11 @@ rule species_id:
         "logs/notebooks/ag-vampir/species-id.log",
     params:
         dataset=dataset,
+        cohort_cols=cohort_cols,
         wkdir=wkdir,
     shell:
         """
-        papermill {input.nb} {output.nb} -k AmpSeq_python -p metadata_path {input.metadata} -p wkdir {params.wkdir} -p vcf_path {input.vcf} -p bed_targets_path {input.bed} 2> {log}
+        papermill {input.nb} {output.nb} -k AmpSeq_python -p metadata_path {input.metadata} -p wkdir {params.wkdir} -p vcf_path {input.vcf} -p bed_targets_path {input.bed} -p cohort_cols {params.cohort_cols} 2> {log}
         cp {output.nb} {output.docs_nb} 2>> {log}
         """
 

--- a/workflow/rules/bcl-convert.smk
+++ b/workflow/rules/bcl-convert.smk
@@ -1,10 +1,13 @@
+import os 
+
 rule bcl_convert:
     input:
-        sample_csv=config["illumina-dir"] + "SampleSheet.csv",
+        sample_csv=os.path.join(config["illumina-dir"], "SampleSheet.csv"),
         illumina_in_dir=config["illumina-dir"],
     output:
-        reads_dir=directory("resources/bcl_output"),
-        fastq_list="resources/bcl_output/Reports/fastq_list.csv",
+        reads_dir=directory("results/bcl_output"),
+        fastq_list="results/bcl_output/Reports/fastq_list.csv",
+        demultiplex_stats = "results/bcl_output/Reports/Demultiplex_Stats.csv",
     singularity:
         "docker://nfcore/bclconvert"
     log:
@@ -18,12 +21,12 @@ rule rename_fastq:
     If users demultiplex from BCL than rename, otherwise symlink to results
     """
     input:
-        reads="resources/bcl_output/",
+        reads="results/bcl_output/",
         read_dir=rules.bcl_convert.output,
-        fastq_list="resources/bcl_output/Reports/fastq_list.csv",
+        fastq_list="results/bcl_output/Reports/fastq_list.csv",
     output:
         output_reads=expand(
-            "resources/reads/{sample}_{n}.fastq.gz", n=[1, 2], sample=samples
+            "results/reads/{sample}_{n}.fastq.gz", n=[1, 2], sample=samples
         ),
     log:
         "logs/rename_fastq.log",
@@ -40,7 +43,7 @@ rule rename_fastq:
             fi
             
             echo renaming $read1 and $read2 to ${{sample_id}}_1.fastq.gz and ${{sample_id}}_2.fastq.gz 
-            mv $read1 resources/reads/${{sample_id}}_1.fastq.gz
-            mv $read2 resources/reads/${{sample_id}}_2.fastq.gz
+            mv $read1 results/reads/${{sample_id}}_1.fastq.gz
+            mv $read2 results/reads/${{sample_id}}_2.fastq.gz
         done < {input.fastq_list}
         """

--- a/workflow/rules/bcl-convert.smk
+++ b/workflow/rules/bcl-convert.smk
@@ -26,7 +26,7 @@ rule rename_fastq:
         fastq_list="results/bcl_output/Reports/fastq_list.csv",
     output:
         output_reads=expand(
-            "results/reads/{sample}_{n}.fastq.gz", n=[1, 2], sample=samples
+            "resources/reads/{sample}_{n}.fastq.gz", n=[1, 2], sample=samples
         ),
     log:
         "logs/rename_fastq.log",
@@ -43,7 +43,7 @@ rule rename_fastq:
             fi
             
             echo renaming $read1 and $read2 to ${{sample_id}}_1.fastq.gz and ${{sample_id}}_2.fastq.gz 
-            mv $read1 results/reads/${{sample_id}}_1.fastq.gz
-            mv $read2 results/reads/${{sample_id}}_2.fastq.gz
+            mv $read1 resources/reads/${{sample_id}}_1.fastq.gz
+            mv $read2 resources/reads/${{sample_id}}_2.fastq.gz
         done < {input.fastq_list}
         """

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -53,7 +53,7 @@ def get_fastqs(wildcards):
     if config["fastq"]["auto"]:
         for i, col in enumerate(fastq_cols):
             metadata = metadata.assign(
-                **{col: f"results/reads/" + metadata["sampleID"] + f"_{i+1}.fastq.gz"}
+                **{col: f"resources/reads/" + metadata["sampleID"] + f"_{i+1}.fastq.gz"}
             )
         metadata = metadata.set_index("sampleID")
     else:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -53,7 +53,7 @@ def get_fastqs(wildcards):
     if config["fastq"]["auto"]:
         for i, col in enumerate(fastq_cols):
             metadata = metadata.assign(
-                **{col: f"resources/reads/" + metadata["sampleID"] + f"_{i+1}.fastq.gz"}
+                **{col: f"results/reads/" + metadata["sampleID"] + f"_{i+1}.fastq.gz"}
             )
         metadata = metadata.set_index("sampleID")
     else:

--- a/workflow/rules/qc-notebooks.smk
+++ b/workflow/rules/qc-notebooks.smk
@@ -29,7 +29,7 @@ rule run_statistics:
         nb=f"{workflow.basedir}/notebooks/run-statistics.ipynb",
         kernel="results/.kernel.set",
         metadata=config["metadata"],
-        demultiplex_stats = "resources/bcl_output/Reports/Demultiplex_Stats.csv",
+        demultiplex_stats = "results/bcl_output/Reports/Demultiplex_Stats.csv",
     output:
         nb="results/notebooks/run-statistics.ipynb",
         docs_nb="docs/ampseeker-results/notebooks/run-statistics.ipynb",
@@ -116,7 +116,7 @@ rule coverage:
         """
 
 
-rule sample_filtering:
+rule sample_quality_control:
     input:
         nb=f"{workflow.basedir}/notebooks/sample-quality-control.ipynb",
         kernel="results/.kernel.set",
@@ -134,9 +134,11 @@ rule sample_filtering:
         "logs/notebooks/sample-quality-control.log",
     params:
         wkdir=wkdir,
-        sample_threshold = config['quality-control']['sample-total-reads-threshold']
+        cohort_cols=cohort_cols,
+        sample_threshold = config['quality-control']['sample-total-reads-threshold'],
+        panel=panel
     shell:
         """
-        papermill {input.nb} {output.nb} -k AmpSeq_python -p metadata_path {input.metadata} -p bed_targets_path {input.targets} -p vcf_path {input.vcf} -p wkdir {params.wkdir} -p sample_total_read_threshold {params.sample_threshold} 2> {log}
+        papermill {input.nb} {output.nb} -k AmpSeq_python -p panel {params.panel} -p metadata_path {input.metadata} -p cohort_cols {params.cohort_cols} -p bed_targets_path {input.targets} -p vcf_path {input.vcf} -p wkdir {params.wkdir} -p sample_total_read_threshold {params.sample_threshold} 2> {log}
         cp {output.nb} {output.docs_nb} 2>> {log}
         """

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -10,11 +10,11 @@ rule index_read_fastqc:
         "logs/index-read-quality.log",
     shell:
         """
-        zcat resources/bcl_output/*I1*.fastq.gz | fastqc stdin --outdir results/qc/index-read-qc/ 2>> {log}
+        zcat results/bcl_output/*I1*.fastq.gz | fastqc stdin --outdir results/qc/index-read-qc/ 2>> {log}
         mv results/qc/index-read-qc/stdin_fastqc.html results/qc/index-read-qc/I1.html 2>> {log}
         mv results/qc/index-read-qc/stdin_fastqc.zip results/qc/index-read-qc/I1.zip 2>> {log}
         
-        zcat resources/bcl_output/*I2*.fastq.gz | fastqc stdin --outdir results/qc/index-read-qc/ 2>> {log}
+        zcat results/bcl_output/*I2*.fastq.gz | fastqc stdin --outdir results/qc/index-read-qc/ 2>> {log}
         mv results/qc/index-read-qc/stdin_fastqc.html results/qc/index-read-qc/I2.html 2>> {log}
         mv results/qc/index-read-qc/stdin_fastqc.zip results/qc/index-read-qc/I2.zip 2>> {log}
         """


### PR DESCRIPTION
Closes #129 , #124 , #122

Small bug fixes, and moves bcl_output to results/. This is better, as when we want to start fresh, we just delete the entire results/ folder. 

We dont yet move renamed reads to results/ because we also want to be able to handle situations where users start from reads and not the BCL folder, and this would complicate that. Essentially, when users start with reads, it should start from resources/. 
