### PR TITLE
swap bcl-convert bcl2fastq and remove singularity

### DIFF
--- a/workflow/envs/AmpSeeker-bcl2fastq.yaml
+++ b/workflow/envs/AmpSeeker-bcl2fastq.yaml
@@ -1,0 +1,7 @@
+name: AmpSeeker-bcl2fastq
+channels:
+  - dranew
+  - bioconda
+dependencies:
+  - rename
+  - bcl2fastq

--- a/workflow/envs/AmpSeeker-cli.yaml
+++ b/workflow/envs/AmpSeeker-cli.yaml
@@ -11,4 +11,3 @@ dependencies:
   - bwa
   - bcftools
   - mosdepth
-  - rename

--- a/workflow/notebooks/run-statistics.ipynb
+++ b/workflow/notebooks/run-statistics.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "815df38c",
    "metadata": {
     "tags": [
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "eec7e40c",
    "metadata": {
     "tags": [
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "f54b15fa",
    "metadata": {
     "tags": [
@@ -72,17 +72,51 @@
     "with open(f\"{wkdir}/config/metadata_colours.json\", 'r') as f:\n",
     "    color_mapping = json.load(f)\n",
     "\n",
-    "demultiplex_data = pd.read_csv(\n",
-    "    f\"{wkdir}/results/bcl_output/Reports/Demultiplex_Stats.csv\"\n",
-    ").rename(columns={'# Reads':'n_reads', 'SampleID':'sample_id'})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "10eeda46",
-   "metadata": {},
-   "source": [
-    "What percentage of total reads are undetermined?"
+    "\n",
+    "# load demux info \n",
+    "with open(f\"{wkdir}/resources/reads/Stats/Stats.json\", \"r\") as file:\n",
+    "    data = json.load(file)\n",
+    "\n",
+    "# Extract DemuxResults\n",
+    "demux_results = []\n",
+    "for conversion_result in data[\"ConversionResults\"]:\n",
+    "    for demux_result in conversion_result[\"DemuxResults\"]:\n",
+    "        sample_id = demux_result[\"SampleId\"]\n",
+    "        number_reads = demux_result.get(\"NumberReads\", None)\n",
+    "        for index_metric in demux_result[\"IndexMetrics\"]:\n",
+    "            index_sequence = index_metric[\"IndexSequence\"]\n",
+    "            mismatch_counts = index_metric[\"MismatchCounts\"]\n",
+    "            mismatch_0 = mismatch_counts.get(\"0\", 0)  # Get mismatch count for 0\n",
+    "            mismatch_1 = mismatch_counts.get(\"1\", 0)  # Get mismatch count for 1\n",
+    "            demux_results.append(\n",
+    "                {\n",
+    "                    \"sample_id\": sample_id,\n",
+    "                    \"n_reads\": number_reads,\n",
+    "                    \"IndexSequence\": index_sequence,\n",
+    "                    \"Mismatch_0\": mismatch_0,\n",
+    "                    \"Mismatch_1\": mismatch_1,\n",
+    "                }\n",
+    "            )\n",
+    "\n",
+    "  # Extract Undetermined data\n",
+    "    if \"Undetermined\" in conversion_result:\n",
+    "        undetermined = conversion_result[\"Undetermined\"]\n",
+    "        number_reads = undetermined.get(\"NumberReads\", None)\n",
+    "        demux_results.append(\n",
+    "            {\n",
+    "                \"sample_id\": \"Undetermined\",\n",
+    "                \"n_reads\": number_reads,\n",
+    "                \"IndexSequence\": None,\n",
+    "                \"Mismatch_0\": None,\n",
+    "                \"Mismatch_1\": None,\n",
+    "            }\n",
+    "        )\n",
+    "\n",
+    "# Convert to DataFrame\n",
+    "demultiplex_data = pd.DataFrame(demux_results).assign(pc_reads=lambda x: x[\"n_reads\"] / x[\"n_reads\"].sum()).assign(\n",
+    "    pc_perfect_index=lambda x: x[\"Mismatch_0\"] / x[\"n_reads\"],\n",
+    "    pc_mismatch_index=lambda x: x[\"Mismatch_1\"] / x[\"n_reads\"]\n",
+    ")"
    ]
   },
   {
@@ -98,7 +132,7 @@
    "outputs": [],
    "source": [
     "n_undetermined = demultiplex_data.query(\"sample_id == 'Undetermined'\")['n_reads'].to_list()[0]\n",
-    "pc_undetermined = demultiplex_data.query(\"sample_id == 'Undetermined'\")['% Reads'].to_list()[0]\n",
+    "pc_undetermined = demultiplex_data.query(\"sample_id == 'Undetermined'\")['pc_reads'].to_list()[0]\n",
     "\n",
     "print(f\"There are {n_undetermined:,} undetermined reads, {pc_undetermined*100}% of all reads\")\n",
     "print(f\"There are {demultiplex_data['n_reads'].sum():,} total reads\")"
@@ -158,7 +192,7 @@
    "source": [
     "fig = px.bar(demultiplex_data, \n",
     "       x='sample_id', \n",
-    "       y='% Perfect Index Reads', \n",
+    "       y='pc_perfect_index', \n",
     "       color=cohort_col, \n",
     "       color_discrete_map=color_mapping[cohort_col],\n",
     "       title='The % of perfect index reads',\n",
@@ -168,7 +202,7 @@
     "\n",
     "fig = px.bar(demultiplex_data.query(\"n_reads > 100\"), \n",
     "       x='sample_id', \n",
-    "       y='% One Mismatch Index Reads', \n",
+    "       y='pc_mismatch_index', \n",
     "       color=cohort_col, \n",
     "       color_discrete_map=color_mapping[cohort_col],\n",
     "       title='The % of Index reads with one mismatch',\n",
@@ -196,7 +230,7 @@
    },
    "outputs": [],
    "source": [
-    "demultiplex_data.loc[:, 'i7'] = demultiplex_data['Index'].str.slice(0,8)\n",
+    "demultiplex_data.loc[:, 'i7'] = demultiplex_data['IndexSequence'].str.slice(0,8)\n",
     "fig = px.box(demultiplex_data, \n",
     "             x='i7', \n",
     "             y='n_reads', \n",
@@ -209,7 +243,7 @@
     "\n",
     "fig2 = px.scatter(demultiplex_data, \n",
     "           x='n_reads', \n",
-    "           y='% Perfect Index Reads', \n",
+    "           y='pc_perfect_index', \n",
     "           color='i7', \n",
     "           hover_data=['well_letter', 'well_number'],\n",
     "           title='The % of perfect index reads against total reads for each i7 index',\n",
@@ -260,7 +294,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -274,7 +308,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/workflow/rules/bcl-convert.smk
+++ b/workflow/rules/bcl-convert.smk
@@ -16,6 +16,9 @@ rule bcl_convert:
     shell:
         """
         bcl2fastq --runfolder-dir {input.illumina_in_dir} --output-dir resources/reads/ --sample-sheet {input.sample_csv} 2> {log}
-        rename 's/L001_//; s/_001//; s/S\d+_R//; s/S\d+_//' resources/reads/*fastq.gz 2>> {log}
+        rename 's/_S\d+_L001_//; s/R1_001/_1/' resources/reads/*R1_*fastq.gz
+        rename 's/_S\d+_L001_//; s/R2_001/_2/' resources/reads/*R2_*fastq.gz
+        rename 's/_S\d+_L001_//; s/I1_001/_I1/' resources/reads/*I1_*fastq.gz
+        rename 's/_S\d+_L001_//; s/I2_001/_I2/' resources/reads/*I2_*fastq.gz
         """
 

--- a/workflow/rules/bcl-convert.smk
+++ b/workflow/rules/bcl-convert.smk
@@ -5,43 +5,17 @@ rule bcl_convert:
         sample_csv=os.path.join(config["illumina-dir"], "SampleSheet.csv"),
         illumina_in_dir=config["illumina-dir"],
     output:
-        reads_dir=directory("results/bcl_output"),
-        fastq_list="results/bcl_output/Reports/fastq_list.csv",
-        demultiplex_stats = "results/bcl_output/Reports/Demultiplex_Stats.csv",
-    singularity:
-        "docker://nfcore/bclconvert"
-    log:
-        "logs/bcl_convert.log",
-    shell:
-        "bcl-convert --bcl-input-directory {input.illumina_in_dir} --output-directory {output.reads_dir} --sample-sheet {input.sample_csv} --force 2> {log}"
-
-
-rule rename_fastq:
-    """
-    If users demultiplex from BCL than rename, otherwise symlink to results
-    """
-    input:
-        reads="results/bcl_output/",
-        read_dir=rules.bcl_convert.output,
-        fastq_list="results/bcl_output/Reports/fastq_list.csv",
-    output:
         output_reads=expand(
             "resources/reads/{sample}_{n}.fastq.gz", n=[1, 2], sample=samples
         ),
+        demultiplex_stats = "resources/reads/Stats/DemultiplexingStats.xml",
     conda:
-        "../envs/AmpSeeker-cli.yaml"
-    params:
-        wd=wkdir,
+        "../envs/AmpSeeker-bcl2fastq.yaml"
+    log:
+        "logs/bcl2fastq.log",
     shell:
         """
-        while IFS="," read -r _ sample_id _ _ read1 read2; do
-            
-            if [[ $sample_id == "RGSM" ]]; then
-               continue
-            fi
-            
-            echo renaming $read1 and $read2 to ${{sample_id}}_1.fastq.gz and ${{sample_id}}_2.fastq.gz 
-            mv $read1 resources/reads/${{sample_id}}_1.fastq.gz
-            mv $read2 resources/reads/${{sample_id}}_2.fastq.gz
-        done < {input.fastq_list}
+        bcl2fastq --runfolder-dir {input.illumina_in_dir} --output-dir resources/reads/ --sample-sheet {input.sample_csv} 2> {log}
+        rename 's/L001_//; s/_001//; s/S\d+_R//; s/S\d+_//' resources/reads/*fastq.gz 2>> {log}
         """
+

--- a/workflow/rules/qc-notebooks.smk
+++ b/workflow/rules/qc-notebooks.smk
@@ -29,7 +29,7 @@ rule run_statistics:
         nb=f"{workflow.basedir}/notebooks/run-statistics.ipynb",
         kernel="results/.kernel.set",
         metadata=config["metadata"],
-        demultiplex_stats = "results/bcl_output/Reports/Demultiplex_Stats.csv",
+        demultiplex_stats = "resources/reads/Stats/DemultiplexingStats.xml",
     output:
         nb="results/notebooks/run-statistics.ipynb",
         docs_nb="docs/ampseeker-results/notebooks/run-statistics.ipynb",

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -10,11 +10,11 @@ rule index_read_fastqc:
         "logs/index-read-quality.log",
     shell:
         """
-        zcat results/bcl_output/*I1*.fastq.gz | fastqc stdin --outdir results/qc/index-read-qc/ 2>> {log}
+        zcat resources/reads/*I1*.fastq.gz | fastqc stdin --outdir results/qc/index-read-qc/ 2>> {log}
         mv results/qc/index-read-qc/stdin_fastqc.html results/qc/index-read-qc/I1.html 2>> {log}
         mv results/qc/index-read-qc/stdin_fastqc.zip results/qc/index-read-qc/I1.zip 2>> {log}
         
-        zcat results/bcl_output/*I2*.fastq.gz | fastqc stdin --outdir results/qc/index-read-qc/ 2>> {log}
+        zcat resources/reads/*I2*.fastq.gz | fastqc stdin --outdir results/qc/index-read-qc/ 2>> {log}
         mv results/qc/index-read-qc/stdin_fastqc.html results/qc/index-read-qc/I2.html 2>> {log}
         mv results/qc/index-read-qc/stdin_fastqc.zip results/qc/index-read-qc/I2.zip 2>> {log}
         """


### PR DESCRIPTION
This PR addresses #162. 

Bcl convert required we use singularity to install it, but it was causing some installation problems for users. By switching back to bcl2fastq, we now simplify the packages needed to run the workflow. 
