### PR TITLE
misc improvements - 14 April

### DIFF
--- a/.test/config/config_agvampir.yaml
+++ b/.test/config/config_agvampir.yaml
@@ -22,7 +22,6 @@ quality-control:
   sample-total-reads-threshold: 250
   amplicon-total-reads-threshold: 1000
 
-  fastp: True
   coverage: True
   stats: True
   multiqc: True

--- a/.test/config/config_agvampir.yaml
+++ b/.test/config/config_agvampir.yaml
@@ -1,11 +1,13 @@
 dataset: test-agvampir
-metadata: config/metadata.tsv
+metadata: config/metadata-nofq.tsv
 cohort-columns:
   - location
   - taxon
 targets: config/ag-vampir.bed
 panel: ag-vampir
 
+# Specify whether to convert bcl files to fastq
+from-bcl: False
 # Directory of Illumina Miseq Run
 illumina-dir: ""
 
@@ -14,11 +16,6 @@ reference-fasta: resources/reference/AgamP4.fa
 reference-gff3: resources/reference/Anopheles-gambiae-PEST_BASEFEATURES_AgamP4.12.gff3
 reference-snpeffdb: Anopheles_gambiae
 custom-snpeffdb: False
-
-# Specify whether to convert bcl files to fastq
-from-bcl: False
-fastq:
-  auto: False
 
 # Specify whether to run quality-control analyses
 quality-control:

--- a/.test/config/config_fastqauto.yaml
+++ b/.test/config/config_fastqauto.yaml
@@ -25,7 +25,6 @@ quality-control:
   sample-total-reads-threshold: 250
   amplicon-total-reads-threshold: 1000
 
-  fastp: True
   coverage: True
   stats: True
   multiqc: True

--- a/.test/config/config_fastqauto.yaml
+++ b/.test/config/config_fastqauto.yaml
@@ -6,8 +6,10 @@ cohort-columns:
 targets: config/ag-vampir.bed
 panel: generic
 
+
+from-bcl: False
 # Directory of Illumina Miseq Run
-illumina-dir: resources/230629_M05658_0009_000000000-DL7P9/
+illumina-dir: ""
 
 # Specify whether reference  provided is amplicon or wholegenome sequence data
 # Genome fasta reference files
@@ -16,11 +18,7 @@ reference-gff3: resources/reference/Anopheles-gambiae-PEST_BASEFEATURES_AgamP4.1
 reference-snpeffdb: Anopheles_gambiae
 custom-snpeffdb: False
 
-# Specify whether to convert bcl files to fastq
-# or whether we provide fastq data in the metadata / or auto naming 
-from-bcl: False
-fastq:
-  auto: True
+
 
 # Specify whether to run quality-control analyses
 quality-control:

--- a/.test/config/config_fastqmetadata.yaml
+++ b/.test/config/config_fastqmetadata.yaml
@@ -19,7 +19,6 @@ custom-snpeffdb: True
 
 # Specify whether to run quality-control analyses
 quality-control:
-  fastp: True
   coverage: True
   stats: True
   multiqc: True

--- a/.test/config/config_fastqmetadata.yaml
+++ b/.test/config/config_fastqmetadata.yaml
@@ -6,6 +6,8 @@ cohort-columns:
 targets: config/ag-vampir.bed
 panel: generic
 
+# Specify whether to convert bcl files to fastq
+from-bcl: False
 # Directory of Illumina Miseq Run
 illumina-dir: ""
 
@@ -14,11 +16,6 @@ reference-fasta: resources/reference/AgamP4.fa
 reference-gff3: resources/reference/Anopheles-gambiae-PEST_BASEFEATURES_AgamP4.12.gff3
 reference-snpeffdb: Anopheles_gambiae
 custom-snpeffdb: True
-
-# Specify whether to convert bcl files to fastq
-from-bcl: False
-fastq:
-  auto: False
 
 # Specify whether to run quality-control analyses
 quality-control:

--- a/.test/config/metadata-nofq.tsv
+++ b/.test/config/metadata-nofq.tsv
@@ -1,0 +1,11 @@
+sample_id	country	location	taxon	latitude	longitude
+ERR3058522	Ghana	Madina_North	gambiae	5.668	-0.167
+ERR3058532	Ghana	Madina_North	gambiae	5.668	-0.167
+ERR3058542	Ghana	Madina_North	gambiae	5.668	-0.167
+ERR3058552	Ghana	Madina_North	gambiae	5.668	-0.167
+ERR3058562	Ghana	Madina_North	gambiae	5.668	-0.167
+ERR3058572	Ghana	Madina_North	gambiae	5.668	-0.167
+ERR3058582	Ghana	Madina_North	gambiae	5.668	-0.167
+ERR3058982	Benin	Avrankou	coluzzii	5.668	-0.167
+ERR3058992	Benin	Avrankou	coluzzii	6.45	2.25
+ERR3059002	Benin	Avrankou	coluzzii	6.45	2.25

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,4 @@
-# This file should contain everything to configure the workflow on a global scale.
-# In case of sample based data, it should be complemented by a samples.tsv file that contains
-# one row per sample. It can be parsed easily via pandas.
+# Dataset main configurations
 dataset: lab-strains
 panel: ag-vampir
 cohort-columns:
@@ -8,23 +6,17 @@ cohort-columns:
   - taxon
   - country
 targets: config/ag-vampir.bed
-metadata: blah
+metadata: ""
 
+from-bcl: True
 # Directory of Illumina Miseq Run, can be empty 
 illumina-dir: resources/250110_M05658_0028_000000000-LTBV4
 
-# Specify whether reference  provided is amplicon or wholegenome sequence data
 # Genome fasta reference files
 reference-fasta: resources/reference/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa
 reference-gff3: resources/reference/Anopheles-gambiae-PEST_BASEFEATURES_AgamP4.12.gff3
 reference-snpeffdb: Anopheles_gambiae
 custom-snpeffdb: False
-
-# Specify whether to convert bcl files to fastq
-# or whether we provide fastq data in the metadata / or auto naming 
-from-bcl: True
-fastq:
-  auto: True
 
 # Specify whether to run quality-control analyses
 quality-control:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -23,7 +23,6 @@ quality-control:
   sample-total-reads-threshold: 250
   amplicon-total-reads-threshold: 1000
 
-  fastp: True
   coverage: True
   stats: True
   multiqc: True

--- a/config/config_ms.yaml
+++ b/config/config_ms.yaml
@@ -23,8 +23,6 @@ reference-snpeffdb: Anopheles_gambiae
 # Specify whether to convert bcl files to fastq
 # or whether we provide fastq data in the metadata / or auto naming 
 bcl-convert: True
-fastq:
-  auto: True
 
 # Specify whether to run quality-control analyses
 quality-control:

--- a/docs/ampseeker-docs/notebooks/configuring_the_workflow.ipynb
+++ b/docs/ampseeker-docs/notebooks/configuring_the_workflow.ipynb
@@ -125,7 +125,6 @@
     "  sample-total-reads-threshold: 250\n",
     "  amplicon-total-reads-threshold: 1000\n",
     "\n",
-    "  fastp: True\n",
     "  coverage: True\n",
     "  stats: True\n",
     "  multiqc: True\n",
@@ -133,7 +132,6 @@
     "\n",
     "- **quality-control.sample-total-reads-threshold**: Minimum number of reads required for a sample to pass QC. Samples with fewer reads are removed at the quality control stage.\n",
     "- **quality-control.amplicon-total-reads-threshold**: Minimum number of reads required for an amplicon to be considered for analysis.\n",
-    "- **quality-control.fastp**: Whether to run the fastp tool for read quality control and trimming.\n",
     "- **quality-control.coverage**: Whether to calculate and report coverage statistics for each sample.\n",
     "- **quality-control.stats**: Whether to generate alignment and variant calling statistics.\n",
     "- **quality-control.multiqc**: Whether to generate a MultiQC report aggregating various QC metrics."

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -14,6 +14,7 @@ cohort_cols = ','.join(config['cohort-columns'])
 metadata_path = config['metadata'] if not config['from-bcl'] else config['illumina-dir'] + "/SampleSheet.csv"
 metadata = load_metadata(metadata_path, write=True, from_sample_sheet=config['from-bcl'])
 
+fastq_auto = False if all(col in metadata.columns for col in ['fq1', 'fq2']) else True
 plate_info = np.isin(["plate", "well_letter", "well_number"], metadata.columns).all()
 samples = metadata["sample_id"]
 call_types = ["targets", "amplicons"]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -84,7 +84,7 @@ def get_fastqs(wildcards):
     metadata = load_metadata("results/config/metadata.tsv")
     fastq_cols = ["fq1", "fq2"]
 
-    if config["fastq"]["auto"]:
+    if fastq_auto:
         for i, col in enumerate(fastq_cols):
             metadata = metadata.assign(
                 **{col: f"resources/reads/" + metadata["sample_id"] + f"_{i+1}.fastq.gz"}
@@ -262,5 +262,13 @@ def welcome(version):
     print("---------------------------- AmpSeeker ----------------------------")
     print(f"Running AmpSeeker snakemake workflow in {workflow.basedir}\n")
     print(f"Workflow Version: {version}")
-    print("Execution time: ", datetime.datetime.now())
-    print(f"Dataset: {config['dataset']}", "\n")
+    print("Execution time: ", datetime.datetime.now().replace(microsecond=0))
+    print(f"Dataset: {config['dataset']}")
+
+    if config["from-bcl"]:
+        print(f"Input: Illumina Run BCL folder ({config['illumina-dir']})", "\n")
+    elif not config["from-bcl"] and fastq_auto:
+        print(f"Input: fastq files stored in resources/reads/", "\n")
+    elif not config["from-bcl"] and not fastq_auto:
+        print(f"Input: fastq file paths provided in metadata fq1 and fq2 columns", "\n")
+

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -166,18 +166,6 @@ def AmpSeekerOutputs(wildcards):
             )
         )
 
-    if config["quality-control"]["fastp"]:
-        inputs.extend(
-            expand(
-                [
-                    "results/qc/fastp_reports/{sample}.html",
-                    "results/notebooks/read-quality.ipynb",
-                    "docs/ampseeker-results/notebooks/read-quality.ipynb",
-                ],
-                sample=samples,
-            )
-        )
-
     if config["quality-control"]["multiqc"]:
         inputs.extend(
             expand(

--- a/workflow/rules/jupyter-book.smk
+++ b/workflow/rules/jupyter-book.smk
@@ -29,8 +29,6 @@ rule jupyterbook:
         ),
         read_quality=(
             "docs/ampseeker-results/notebooks/read-quality.ipynb"
-            if config["quality-control"]["fastp"]
-            else []
         ),
         reads_per_well=(
             "docs/ampseeker-results/notebooks/reads-per-well.ipynb"
@@ -103,8 +101,6 @@ rule process_notebooks:
         ),
         read_quality=(
             "docs/ampseeker-results/notebooks/read-quality.ipynb"
-            if config["quality-control"]["fastp"]
-            else []
         ),
         reads_per_well=(
             "docs/ampseeker-results/notebooks/reads-per-well.ipynb"

--- a/workflow/rules/metadata.smk
+++ b/workflow/rules/metadata.smk
@@ -5,9 +5,14 @@ def load_metadata(metadata_path, from_sample_sheet=False, write=False):
         from_sample_sheet = True
 
     if not from_sample_sheet:
-        metadata = pd.read_csv(metadata_path, sep="\t")
+        if os.path.exists(metadata_path):
+            metadata = pd.read_csv(metadata_path, sep="\t")
+        else:
+            raise ValueError(f"Metadata file '{metadata_path}' does not exist at the path provided in the config. Is the path correct, or do you mean to run from_bcl=True instead?")
     else:
         metadata = metadata_from_sample_sheet(metadata_path)
+
+    assert all(col in metadata.columns for col in config['cohort-columns']), "Not all provided cohort columns are present in the metadata file" 
     
     if write:
         os.makedirs("results/config", exist_ok=True)
@@ -16,7 +21,6 @@ def load_metadata(metadata_path, from_sample_sheet=False, write=False):
         metadata.to_csv("results/config/metadata.tsv", sep="\t", index=False)
 
     return metadata
-
 
     
 def metadata_from_sample_sheet(sample_sheet_path):

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -99,9 +99,7 @@ rule vcf_stats:
 
 rule multiQC:
     input:
-        expand("results/qc/fastp_reports/{sample}.json", sample=samples)
-        if config["quality-control"]["fastp"]
-        else [],
+        expand("results/qc/fastp_reports/{sample}.json", sample=samples),
         expand("results/alignments/bamStats/{sample}.flagstat", sample=samples)
         if config["quality-control"]["stats"]
         else [],


### PR DESCRIPTION
This PR addresses:

- We remove the fastq auto option. It is inferred from whether there are fq1 and fq2 columns in the metadata or not #180   
- Remove the fastp option - it doesnt do anything as fastp is required #184 